### PR TITLE
Fix plex functions

### DIFF
--- a/PowerShell/VideoFunctions.ps1
+++ b/PowerShell/VideoFunctions.ps1
@@ -284,8 +284,6 @@ function Remove-PlexEmptyFolders {
             continue;
         }
 
-#        Write-Host $path;
-#        Write-Host (Get-ChildItem $path).Count;
         if ((Get-ChildItem $path).Count -eq 0) {
             $foldersDeleted++;
             Remove-Item -Path $path;


### PR DESCRIPTION
### Fix Plex functions

_None of the Plex functions had been tested previously._ Upon trying them out, I encountered several errors. Here are the fixes:
- Only remove `$plexLayout` when it exists
- `throw` for errors instead of invoking `exit` which can terminate the PowerShell host process
- Fix `Add-PlexFolders` not iterating over keys
- Fix `Move-PlexFiles` to actually move files
- Fix `Remove-PlexEmptyFolders` to actually work
- Update `Invoke-PlexFileOperations` to catch errors and write out the error to the host