### PR TITLE
Get-MkvTrack should not exit on mkvextract failure

### DIFF
--- a/PowerShell/VideoFunctions.ps1
+++ b/PowerShell/VideoFunctions.ps1
@@ -45,8 +45,7 @@ function Get-MkvTrack {
     mkvextract "$name.mkv" tracks $track`:"$outputName";
 
     if ($LASTEXITCODE -ne 0) {
-        Write-Host "Failed ($LASTEXITCODE)" -ForegroundColor Red;
-        exit $LASTEXITCODE;
+        Write-Host "Failed (Exit code: $LASTEXITCODE)" -ForegroundColor Red;
     }
     else {
         Write-Host "Complete" -ForegroundColor Blue;
@@ -93,9 +92,6 @@ function Get-MkvTracks {
     foreach ($track in $tracks) {
         $finalExtension = "$track.$extension";
         Get-MkvTrack $name $track $finalExtension;
-        if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE;
-        }
     }
 }
 


### PR DESCRIPTION
In `Get-MkvTrack` don't exit when `mkvextract` fails. Just write out the error to host.