### PR TITLE
Remove Move-Files dependency on 'MP4' folder

### DIFF
--- a/PowerShell/VideoFunctions/Plex.psm1
+++ b/PowerShell/VideoFunctions/Plex.psm1
@@ -79,18 +79,13 @@ function Move-PlexFiles {
         throw "Destination folder does not exist";
     }
 
-    $currentDir = (Get-Location).Path;
-    if (-not $currentDir.EndsWith("MP4")) {
-        throw "Must be in MP4 directory";
-    }
-
     foreach ($folder in $plexLayout.Keys) {
         $fileSuffix = $plexLayout[$folder];
-        $destFiles = "*-$fileSuffix*";
+        $destFiles = (Get-ChildItem "*-$fileSuffix.mp4") + (Get-ChildItem "*-$fileSuffix.srt");
         $destFolder = "$destination\$folder";
         Write-Host "Moving -$fileSuffix to $destFolder";
-        Get-ChildItem $destFiles | ForEach-Object {
-            Move-Item $_.Name "$destFolder";
+        foreach ($destFile in $destFiles) {
+            Move-Item $destFile.Name "$destFolder";
         }
     }
 

--- a/PowerShell/VideoFunctions/Plex.psm1
+++ b/PowerShell/VideoFunctions/Plex.psm1
@@ -81,7 +81,7 @@ function Move-PlexFiles {
 
     foreach ($folder in $plexLayout.Keys) {
         $fileSuffix = $plexLayout[$folder];
-        $destFiles = (Get-ChildItem "*-$fileSuffix.mp4") + (Get-ChildItem "*-$fileSuffix.srt");
+        $destFiles = (Get-ChildItem -Recurse "*-$fileSuffix.mp4") + (Get-ChildItem -Recurse "*-$fileSuffix.srt");
         $destFolder = "$destination\$folder";
         Write-Host "Moving -$fileSuffix to $destFolder";
         foreach ($destFile in $destFiles) {


### PR DESCRIPTION
The `Move-PlexFiles` command required that they be located in a folder named `MP4`. This is a personal choice on my behalf and shouldn't be enforced on all users. Instead, intelligently copy videos (MP4) and subtitles (SRT) from the current directory and child directories to the Plex folders.