### PR TITLE
Add install scripts (Cursor)

### DIFF
--- a/PowerShell/VideoFunctions/Install-VideoFunctions.ps1
+++ b/PowerShell/VideoFunctions/Install-VideoFunctions.ps1
@@ -1,0 +1,253 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Installs the VideoFunctions PowerShell module.
+
+.DESCRIPTION
+    This script installs the VideoFunctions module to the appropriate PowerShell modules directory.
+    It supports both Windows PowerShell and PowerShell Core, and can install for the current user
+    or for all users (requires elevation).
+
+.PARAMETER Scope
+    Specifies the installation scope. Valid values are 'CurrentUser' and 'AllUsers'.
+    Default is 'CurrentUser'. 'AllUsers' requires elevation.
+
+.PARAMETER Force
+    Forces the installation even if the module already exists.
+
+.PARAMETER WhatIf
+    Shows what would happen if the script runs without actually performing the installation.
+
+.PARAMETER Confirm
+    Prompts for confirmation before performing the installation.
+
+.EXAMPLE
+    .\Install-VideoFunctions.ps1
+
+    Installs the module for the current user.
+
+.EXAMPLE
+    .\Install-VideoFunctions.ps1 -Scope AllUsers
+
+    Installs the module for all users (requires elevation).
+
+.EXAMPLE
+    .\Install-VideoFunctions.ps1 -Force
+
+    Forces installation even if the module already exists.
+
+.EXAMPLE
+    .\Install-VideoFunctions.ps1 -WhatIf
+
+    Shows what would happen without actually installing.
+
+.NOTES
+    This script should be run from the directory containing the VideoFunctions module.
+    For AllUsers installation, the script must be run with administrative privileges.
+#>
+
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+param(
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('CurrentUser', 'AllUsers')]
+    [string]$Scope = 'CurrentUser',
+    
+    [Parameter(Mandatory = $false)]
+    [switch]$Force
+)
+
+# Set strict error handling
+$ErrorActionPreference = 'Stop'
+
+function Write-InstallMessage {
+    param(
+        [string]$Message,
+        [string]$Type = 'Info'
+    )
+    
+    $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    switch ($Type) {
+        'Info'    { Write-Host "[$timestamp] INFO: $Message" -ForegroundColor Cyan }
+        'Success' { Write-Host "[$timestamp] SUCCESS: $Message" -ForegroundColor Green }
+        'Warning' { Write-Host "[$timestamp] WARNING: $Message" -ForegroundColor Yellow }
+        'Error'   { Write-Host "[$timestamp] ERROR: $Message" -ForegroundColor Red }
+    }
+}
+
+function Test-Administrator {
+    <#
+    .SYNOPSIS
+        Tests if the current session is running with administrative privileges.
+    #>
+    $currentUser = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($currentUser)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Get-ModuleInstallPath {
+    param(
+        [string]$Scope
+    )
+    
+    if ($Scope -eq 'AllUsers') {
+        if ($PSVersionTable.PSEdition -eq 'Core') {
+            return "$env:ProgramFiles\PowerShell\Modules"
+        } else {
+            return "$env:ProgramFiles\WindowsPowerShell\Modules"
+        }
+    } else {
+        if ($PSVersionTable.PSEdition -eq 'Core') {
+            return "$env:USERPROFILE\Documents\PowerShell\Modules"
+        } else {
+            return "$env:USERPROFILE\Documents\WindowsPowerShell\Modules"
+        }
+    }
+}
+
+function Test-ModuleStructure {
+    <#
+    .SYNOPSIS
+        Tests if the current directory contains a valid VideoFunctions module structure.
+    #>
+    $requiredFiles = @(
+        'VideoFunctions.psd1',
+        'VideoFunctions.psm1'
+    )
+    
+    $requiredDirectories = @(
+        'Public',
+        'Private'
+    )
+    
+    # Check for required files
+    foreach ($file in $requiredFiles) {
+        if (-not (Test-Path $file)) {
+            Write-InstallMessage "Required file '$file' not found in current directory." 'Error'
+            return $false
+        }
+    }
+    
+    # Check for required directories
+    foreach ($dir in $requiredDirectories) {
+        if (-not (Test-Path $dir)) {
+            Write-InstallMessage "Required directory '$dir' not found in current directory." 'Error'
+            return $false
+        }
+    }
+    
+    # Check for at least one function file in Public directory
+    $publicFunctions = Get-ChildItem -Path 'Public' -Filter '*.ps1' -ErrorAction SilentlyContinue
+    if ($publicFunctions.Count -eq 0) {
+        Write-InstallMessage "No function files found in Public directory." 'Error'
+        return $false
+    }
+    
+    return $true
+}
+
+function Get-ModuleVersion {
+    <#
+    .SYNOPSIS
+        Gets the version from the module manifest.
+    #>
+    try {
+        $manifest = Import-PowerShellDataFile -Path 'VideoFunctions.psd1'
+        return $manifest.ModuleVersion
+    }
+    catch {
+        Write-InstallMessage "Failed to read module version from manifest: $($_.Exception.Message)" 'Warning'
+        return 'Unknown'
+    }
+}
+
+# Main installation logic
+try {
+    Write-InstallMessage "Starting VideoFunctions module installation..."
+    Write-InstallMessage "PowerShell Version: $($PSVersionTable.PSVersion)"
+    Write-InstallMessage "PowerShell Edition: $($PSVersionTable.PSEdition)"
+    Write-InstallMessage "Installation Scope: $Scope"
+    
+    # Check if running from the correct directory
+    if (-not (Test-ModuleStructure)) {
+        throw "Current directory does not contain a valid VideoFunctions module structure. Please run this script from the VideoFunctions module directory."
+    }
+    
+    # Check for administrative privileges if installing for all users
+    if ($Scope -eq 'AllUsers' -and -not (Test-Administrator)) {
+        throw "Administrative privileges are required to install for all users. Please run PowerShell as Administrator or use -Scope CurrentUser."
+    }
+    
+    # Get installation path
+    $installPath = Get-ModuleInstallPath -Scope $Scope
+    $modulePath = Join-Path $installPath 'VideoFunctions'
+    
+    Write-InstallMessage "Installation path: $modulePath"
+    
+    # Check if module already exists
+    if (Test-Path $modulePath) {
+        if ($Force) {
+            Write-InstallMessage "Module already exists. Force flag specified, will overwrite existing installation." 'Warning'
+        } else {
+            throw "Module already exists at '$modulePath'. Use -Force to overwrite or -Scope CurrentUser to install for current user only."
+        }
+    }
+    
+    # Get current module version
+    $moduleVersion = Get-ModuleVersion
+    Write-InstallMessage "Installing VideoFunctions version $moduleVersion"
+    
+    # Perform the installation
+    if ($PSCmdlet.ShouldProcess($modulePath, "Install VideoFunctions module")) {
+        # Create the module directory if it doesn't exist
+        if (-not (Test-Path $installPath)) {
+            Write-InstallMessage "Creating modules directory: $installPath"
+            New-Item -Path $installPath -ItemType Directory -Force | Out-Null
+        }
+        
+        # Copy the module files
+        Write-InstallMessage "Copying module files to: $modulePath"
+        Copy-Item -Path '.' -Destination $modulePath -Recurse -Force
+        
+        # Verify the installation
+        if (Test-Path $modulePath) {
+            Write-InstallMessage "Module files copied successfully." 'Success'
+            
+            # Test module import
+            Write-InstallMessage "Testing module import..."
+            try {
+                Import-Module $modulePath -Force -ErrorAction Stop
+                $importedFunctions = Get-Command -Module VideoFunctions
+                Write-InstallMessage "Module imported successfully. Found $($importedFunctions.Count) functions." 'Success'
+                
+                # Show available functions
+                Write-InstallMessage "Available functions:"
+                foreach ($function in $importedFunctions) {
+                    Write-Host "  - $($function.Name)" -ForegroundColor White
+                }
+                
+                # Remove the module to clean up
+                Remove-Module VideoFunctions -Force -ErrorAction SilentlyContinue
+                
+            } catch {
+                Write-InstallMessage "Module import test failed: $($_.Exception.Message)" 'Error'
+                throw
+            }
+            
+        } else {
+            throw "Failed to copy module files to $modulePath"
+        }
+    }
+    
+    Write-InstallMessage "Installation completed successfully!" 'Success'
+    Write-InstallMessage "To use the module, run: Import-Module VideoFunctions" 'Info'
+    
+    # Show usage examples
+    Write-InstallMessage "Example usage:" 'Info'
+    Write-Host "  Import-Module VideoFunctions" -ForegroundColor White
+    Write-Host "  Get-Command -Module VideoFunctions" -ForegroundColor White
+    Write-Host "  Get-Help Get-FFMpegVersion" -ForegroundColor White
+    
+} catch {
+    Write-InstallMessage "Installation failed: $($_.Exception.Message)" 'Error'
+    exit 1
+} 

--- a/PowerShell/VideoFunctions/README.md
+++ b/PowerShell/VideoFunctions/README.md
@@ -17,17 +17,48 @@ A PowerShell module for video file processing and Plex folder management. This m
 - FFmpeg (for FFmpeg-related functions)
 - MKVToolNix (for MKV processing functions)
 
-### Manual Installation
+### Quick Installation
 
 1. Clone or download this repository
-2. Copy the `VideoFunctions` folder to your PowerShell modules directory:
+2. Navigate to the `VideoFunctions` directory
+3. Run the installation script:
+
+```powershell
+# Install for current user (recommended)
+.\Install-VideoFunctions.ps1
+
+# Install for all users (requires elevation)
+.\Install-VideoFunctions.ps1 -Scope AllUsers
+
+# Force installation (overwrites existing)
+.\Install-VideoFunctions.ps1 -Force
+```
+
+### Manual Installation
+
+1. Copy the `VideoFunctions` folder to your PowerShell modules directory:
    - **Windows**: `$env:USERPROFILE\Documents\WindowsPowerShell\Modules\`
    - **PowerShell Core**: `$env:USERPROFILE\Documents\PowerShell\Modules\`
 
-3. Import the module:
+2. Import the module:
    ```powershell
    Import-Module VideoFunctions
    ```
+
+### Uninstallation
+
+To remove the module from your system:
+
+```powershell
+# Uninstall from all locations
+.\Uninstall-VideoFunctions.ps1
+
+# Uninstall from current user only
+.\Uninstall-VideoFunctions.ps1 -Scope CurrentUser
+
+# Uninstall from all users only (requires elevation)
+.\Uninstall-VideoFunctions.ps1 -Scope AllUsers
+```
 
 ## Module Structure
 
@@ -37,6 +68,8 @@ The module follows PowerShell best practices with organized function structure:
 VideoFunctions/
 ├── VideoFunctions.psd1          # Module manifest
 ├── VideoFunctions.psm1          # Root module file
+├── Install-VideoFunctions.ps1   # Installation script
+├── Uninstall-VideoFunctions.ps1 # Uninstallation script
 ├── Public/                      # Public functions (exported)
 │   ├── Get-FFMpegVersion.ps1
 │   ├── Invoke-FFProbe.ps1
@@ -48,10 +81,11 @@ VideoFunctions/
 │   ├── Move-PlexFiles.ps1
 │   ├── Remove-PlexEmptyFolders.ps1
 │   └── Invoke-PlexFileOperations.ps1
-└── Private/                     # Private helper functions
-    ├── Test-FFMpegInstalled.ps1
-    ├── Get-FileFromPath.ps1
-    └── Invoke-Process.ps1
+├── Private/                     # Private helper functions
+│   ├── Test-FFMpegInstalled.ps1
+│   ├── Get-FileFromPath.ps1
+│   └── Invoke-Process.ps1
+└── README.md
 ```
 
 ## Available Functions
@@ -194,6 +228,41 @@ The module includes comprehensive error handling:
 - File existence validation
 - Process execution error handling
 - Detailed error messages and logging
+
+## Installation Scripts
+
+### Install-VideoFunctions.ps1
+
+The installation script provides the following features:
+
+- **Automatic Detection**: Detects PowerShell version and edition
+- **Scope Support**: Install for current user or all users
+- **Validation**: Verifies module structure before installation
+- **Testing**: Tests module import after installation
+- **Error Handling**: Comprehensive error handling and logging
+- **WhatIf Support**: Preview installation without executing
+
+**Parameters:**
+- `-Scope`: 'CurrentUser' (default) or 'AllUsers'
+- `-Force`: Overwrite existing installation
+- `-WhatIf`: Preview installation
+- `-Confirm`: Prompt for confirmation
+
+### Uninstall-VideoFunctions.ps1
+
+The uninstallation script provides the following features:
+
+- **Complete Removal**: Removes module from all locations
+- **Scope Support**: Remove from specific scopes
+- **Memory Cleanup**: Removes module from memory if loaded
+- **Verification**: Confirms complete removal
+- **Safety**: Prompts for confirmation by default
+
+**Parameters:**
+- `-Scope`: 'CurrentUser', 'AllUsers', or 'All' (default)
+- `-Force`: Skip confirmation prompts
+- `-WhatIf`: Preview uninstallation
+- `-Confirm`: Prompt for confirmation
 
 ## Contributing
 

--- a/PowerShell/VideoFunctions/Uninstall-VideoFunctions.ps1
+++ b/PowerShell/VideoFunctions/Uninstall-VideoFunctions.ps1
@@ -1,0 +1,241 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Uninstalls the VideoFunctions PowerShell module.
+
+.DESCRIPTION
+    This script removes the VideoFunctions module from the PowerShell modules directory.
+    It supports both Windows PowerShell and PowerShell Core, and can uninstall from
+    current user or all users scope (requires elevation).
+
+.PARAMETER Scope
+    Specifies the uninstallation scope. Valid values are 'CurrentUser', 'AllUsers', and 'All'.
+    Default is 'All' which checks both scopes. 'AllUsers' requires elevation.
+
+.PARAMETER Force
+    Forces the uninstallation without prompting for confirmation.
+
+.PARAMETER WhatIf
+    Shows what would happen if the script runs without actually performing the uninstallation.
+
+.PARAMETER Confirm
+    Prompts for confirmation before performing the uninstallation.
+
+.EXAMPLE
+    .\Uninstall-VideoFunctions.ps1
+
+    Uninstalls the module from all locations where it's found.
+
+.EXAMPLE
+    .\Uninstall-VideoFunctions.ps1 -Scope CurrentUser
+
+    Uninstalls the module only from the current user's modules directory.
+
+.EXAMPLE
+    .\Uninstall-VideoFunctions.ps1 -Scope AllUsers
+
+    Uninstalls the module only from the all users modules directory (requires elevation).
+
+.EXAMPLE
+    .\Uninstall-VideoFunctions.ps1 -Force
+
+    Forces uninstallation without prompting for confirmation.
+
+.EXAMPLE
+    .\Uninstall-VideoFunctions.ps1 -WhatIf
+
+    Shows what would happen without actually uninstalling.
+
+.NOTES
+    This script can be run from any directory.
+    For AllUsers uninstallation, the script must be run with administrative privileges.
+#>
+
+[CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+param(
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('CurrentUser', 'AllUsers', 'All')]
+    [string]$Scope = 'All',
+    
+    [Parameter(Mandatory = $false)]
+    [switch]$Force
+)
+
+# Set strict error handling
+$ErrorActionPreference = 'Stop'
+
+function Write-UninstallMessage {
+    param(
+        [string]$Message,
+        [string]$Type = 'Info'
+    )
+    
+    $timestamp = Get-Date -Format 'yyyy-MM-dd HH-mm-ss'
+    switch ($Type) {
+        'Info'    { Write-Host ("[$timestamp] INFO: " + $Message) -ForegroundColor Cyan }
+        'Success' { Write-Host ("[$timestamp] SUCCESS: " + $Message) -ForegroundColor Green }
+        'Warning' { Write-Host ("[$timestamp] WARNING: " + $Message) -ForegroundColor Yellow }
+        'Error'   { Write-Host ("[$timestamp] ERROR: " + $Message) -ForegroundColor Red }
+    }
+}
+
+function Test-Administrator {
+    <#
+    .SYNOPSIS
+        Tests if the current session is running with administrative privileges.
+    #>
+    $currentUser = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($currentUser)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Get-ModulePaths {
+    <#
+    .SYNOPSIS
+        Gets all possible module paths for VideoFunctions.
+    #>
+    $paths = @()
+    
+    # Current User paths
+    if ($Scope -in @('CurrentUser', 'All')) {
+        if ($PSVersionTable.PSEdition -eq 'Core') {
+            $paths += "$env:USERPROFILE\Documents\PowerShell\Modules\VideoFunctions"
+        } else {
+            $paths += "$env:USERPROFILE\Documents\WindowsPowerShell\Modules\VideoFunctions"
+        }
+    }
+    
+    # All Users paths
+    if ($Scope -in @('AllUsers', 'All')) {
+        if ($PSVersionTable.PSEdition -eq 'Core') {
+            $paths += "$env:ProgramFiles\PowerShell\Modules\VideoFunctions"
+        } else {
+            $paths += "$env:ProgramFiles\WindowsPowerShell\Modules\VideoFunctions"
+        }
+    }
+    
+    return $paths
+}
+
+function Test-ModuleInstalled {
+    <#
+    .SYNOPSIS
+        Tests if the VideoFunctions module is installed and returns installation locations.
+    #>
+    $modulePaths = Get-ModulePaths
+    $installedPaths = @()
+    
+    foreach ($path in $modulePaths) {
+        if (Test-Path $path) {
+            $installedPaths += $path
+        }
+    }
+    
+    return $installedPaths
+}
+
+function Get-ModuleInfo {
+    param(
+        [string]$ModulePath
+    )
+    
+    try {
+        $manifestPath = Join-Path $ModulePath 'VideoFunctions.psd1'
+        if (Test-Path $manifestPath) {
+            $manifest = Import-PowerShellDataFile -Path $manifestPath
+            return @{
+                Version = $manifest.ModuleVersion
+                Author = $manifest.Author
+                Description = $manifest.Description
+            }
+        }
+    }
+    catch {
+        Write-UninstallMessage ("Failed to read module info from $ModulePath`:" + $_.Exception.Message) 'Warning'
+    }
+    
+    return @{
+        Version = 'Unknown'
+        Author = 'Unknown'
+        Description = 'Unknown'
+    }
+}
+
+# Main uninstallation logic
+try {
+    Write-UninstallMessage "Starting VideoFunctions module uninstallation..."
+    Write-UninstallMessage "PowerShell Version: $($PSVersionTable.PSVersion)"
+    Write-UninstallMessage "PowerShell Edition: $($PSVersionTable.PSEdition)"
+    Write-UninstallMessage "Uninstallation Scope: $Scope"
+    
+    # Check for administrative privileges if needed
+    if ($Scope -eq 'AllUsers' -and -not (Test-Administrator)) {
+        throw "Administrative privileges are required to uninstall from AllUsers scope. Please run PowerShell as Administrator or use -Scope CurrentUser."
+    }
+    
+    # Find installed modules
+    $installedPaths = Test-ModuleInstalled
+    
+    if ($installedPaths.Count -eq 0) {
+        Write-UninstallMessage "VideoFunctions module is not installed in the specified scope(s)." 'Warning'
+        return
+    }
+    
+    Write-UninstallMessage "Found VideoFunctions module in $($installedPaths.Count) location(s):"
+    foreach ($path in $installedPaths) {
+        $moduleInfo = Get-ModuleInfo -ModulePath $path
+        Write-Host "  - $path (Version: $($moduleInfo.Version))" -ForegroundColor White
+    }
+    
+    # Check if module is currently loaded
+    $loadedModule = Get-Module VideoFunctions -ErrorAction SilentlyContinue
+    if ($loadedModule) {
+        Write-UninstallMessage "Module is currently loaded. Attempting to remove..." 'Warning'
+        try {
+            Remove-Module VideoFunctions -Force -ErrorAction Stop
+            Write-UninstallMessage "Module removed from memory successfully." 'Success'
+        }
+        catch {
+            Write-UninstallMessage "Failed to remove module from memory: $($_.Exception.Message)" 'Warning'
+            Write-UninstallMessage "Please close any PowerShell sessions using the module and try again." 'Info'
+        }
+    }
+    
+    # Perform the uninstallation
+    foreach ($path in $installedPaths) {
+        if ($PSCmdlet.ShouldProcess($path, "Remove VideoFunctions module")) {
+            try {
+                Write-UninstallMessage "Removing module from: $path"
+                
+                # Get module info before removal
+                $moduleInfo = Get-ModuleInfo -ModulePath $path
+                
+                # Remove the module directory
+                Remove-Item -Path $path -Recurse -Force -ErrorAction Stop
+                
+                Write-UninstallMessage "Successfully removed VideoFunctions version $($moduleInfo.Version) from $path" 'Success'
+            }
+            catch {
+                Write-UninstallMessage ("Failed to remove module from $path`:" + $_.Exception.Message) 'Error'
+                throw
+            }
+        }
+    }
+    
+    # Verify uninstallation
+    $remainingPaths = Test-ModuleInstalled
+    if ($remainingPaths.Count -eq 0) {
+        Write-UninstallMessage "Uninstallation completed successfully!" 'Success'
+        Write-UninstallMessage "VideoFunctions module has been completely removed from the system." 'Info'
+    } else {
+        Write-UninstallMessage "Uninstallation completed with warnings." 'Warning'
+        Write-UninstallMessage "Remaining module locations:"
+        foreach ($path in $remainingPaths) {
+            Write-Host "  - $path" -ForegroundColor Yellow
+        }
+    }
+    
+} catch {
+    Write-UninstallMessage "Uninstallation failed: $($_.Exception.Message)" 'Error'
+    exit 1
+} 


### PR DESCRIPTION
_**This change was created by Cursor**_

An install script (`Install-VideoFunctions.ps1`) and an uninstall script (`Uninstall-VideoFunctions.ps1`) have been added to the module root. Here’s what you get:

---

### Install Script (`Install-VideoFunctions.ps1`)
* Usage:
```
  # Install for current user (recommended)
  .\Install-VideoFunctions.ps1

  # Install for all users (requires elevation)
  .\Install-VideoFunctions.ps1 -Scope AllUsers

  # Force installation (overwrites existing)
  .\Install-VideoFunctions.ps1 -Force
```

* Features:
    * Installs the module to the correct PowerShell modules directory for your edition and scope.
    * Validates the module structure before installing.
    * Supports `-Scope` (_CurrentUser_ or _AllUsers_), `-Force`, `-WhatIf`, and `-Confirm`.
    * Tests module import after installation and lists available functions.
   * Provides clear, color-coded status and error messages.

---

### Uninstall Script (`Uninstall-VideoFunctions.ps1`)
* Usage:
```
  # Uninstall from all locations
  .\Uninstall-VideoFunctions.ps1

  # Uninstall from current user only
  .\Uninstall-VideoFunctions.ps1 -Scope CurrentUser

  # Uninstall from all users only (requires elevation)
  .\Uninstall-VideoFunctions.ps1 -Scope AllUsers
```
* Features:
    * Removes the module from all or specific module directories.
    * Handles both Windows PowerShell and PowerShell Core locations.
    * Supports `-Scope`, `-Force`, `-WhatIf`, and `-Confirm`.         
    * Attempts to unload the module from memory if it’s loaded.
    * Verifies and reports on successful removal.

---

Both scripts provide robust error handling, clear output, and are documented in the README.
You can now install or uninstall the module with a single command!