### PR TITLE
Add Export-MediaStream function

### DIFF
--- a/PowerShell/VideoFunctions/Public/Export-MediaStream.ps1
+++ b/PowerShell/VideoFunctions/Public/Export-MediaStream.ps1
@@ -52,6 +52,10 @@ function Export-MediaStream {
         Export-MediaStream -InputPath 'video.mp4' -OutputPath 'stream_2.raw' -Type Data -Index 2 -Force
         Extracts the third data stream from 'video.mp4' and saves it as 'stream_2.raw', overwriting if it exists.
 
+    .EXAMPLE
+        Get-ChildItem -Filter "*.mp4" | Export-MediaStream -OutputPath "audio.aac" -Type Audio -Index 0
+        Extracts the first audio stream from all MP4 files in the current directory and saves them as "audio.aac".
+
     .OUTPUTS
         None. Creates a file at the specified OutputPath.
 
@@ -63,7 +67,7 @@ function Export-MediaStream {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
     [OutputType([void])]
     param (
-        [Parameter(Mandatory, Position = 0)]
+        [Parameter(Mandatory, Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [ValidateNotNullOrEmpty()]
         [string]$InputPath,
         

--- a/PowerShell/VideoFunctions/Public/Export-MediaStream.ps1
+++ b/PowerShell/VideoFunctions/Public/Export-MediaStream.ps1
@@ -1,0 +1,14 @@
+function Export-MediaStream {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        
+        [Parameter(Mandatory = $false)]
+        [string]$OutputPath
+    )
+    
+    # TODO: Implement media stream export functionality
+    Write-Verbose "Export-MediaStream: Stub function - not yet implemented"
+    Write-Host "Export-MediaStream function is a stub and not yet implemented."
+} 

--- a/PowerShell/VideoFunctions/Public/Export-MediaStream.ps1
+++ b/PowerShell/VideoFunctions/Public/Export-MediaStream.ps1
@@ -9,7 +9,7 @@ enum StreamType {
 function Export-MediaStream {
     <#
     .SYNOPSIS
-        Extracts a raw stream from a media file using ffmpeg.
+        Extracts a stream from a media file using ffmpeg.
 
     .DESCRIPTION
         This function uses ffmpeg to extract a specific stream from a media file

--- a/PowerShell/VideoFunctions/Public/Export-MediaStream.ps1
+++ b/PowerShell/VideoFunctions/Public/Export-MediaStream.ps1
@@ -91,7 +91,7 @@ function Export-MediaStream {
         [ValidateRange(0, [int]::MaxValue)]
         [int]$Index,
         
-        [Parameter]
+        [Parameter()]
         [switch]$Force
     )
 

--- a/PowerShell/VideoFunctions/VideoFunctions.psd1
+++ b/PowerShell/VideoFunctions/VideoFunctions.psd1
@@ -77,19 +77,13 @@ FunctionsToExport = @(
     # Media
     'Get-MediaStream',
     'Get-MediaStreams',
-    'Export-MediaStreamContent',
+    'Export-MediaStream',
 
     # Mkv
     'Get-MkvTrack',
     'Get-MkvTracks',
     'Get-MkvTrackAll',
 
-<<<<<<< HEAD
-    # Mpeg
-    'Get-MpegStreams',
-
-=======
->>>>>>> a150dcb (Rename Get-MpegStream* to Get-MediaStream*)
     # Plex
     'Add-PlexFolders', 
     'Move-PlexFiles',

--- a/PowerShell/VideoFunctions/VideoFunctions.psm1
+++ b/PowerShell/VideoFunctions/VideoFunctions.psm1
@@ -41,7 +41,7 @@ Export-ModuleMember -Function @(
     # Media functions
     'Get-MediaStream',
     'Get-MediaStreams',
-    'Export-MediaStreamContent',
+    'Export-MediaStream',
 
     # MKV functions
     'Get-MkvTrack',


### PR DESCRIPTION
# Export-MediaStream

## Description
This function uses ffmpeg to extract a specific stream from a media file and outputs it as a raw stream file. The stream can be filtered by type (Audio, Video, Subtitle, Data, None) and selected by index.

## Parameters
* `InputPath`: Path to the input media file.
* `OutputPath`: Path where the raw stream file will be saved.
* `Type`: Type of stream to filter by. Must be one of: Audio, Video, Subtitle, Data, or None.
* `Index`: Zero-based index of the stream to extract. When Type is specified (Audio, Video, etc.), this is the index within that stream type. When Type is None, this is the absolute stream index regardless of type.
* `Force`: Overwrites the output file if it already exists.
* `WhatIf`: Shows what would happen if the command runs without actually executing it.
* `Confirm`: Prompts for confirmation before executing the command.


## Examples
1. `Export-MediaStream -InputPath 'video.mp4' -OutputPath 'audio.rac3 -Type Audio -Index 0`
    * Extracts the first audio stream from 'video.mp4' and saves it as 'audio.ac3'.

1. `Export-MediaStream -InputPath 'video.mp4' -OutputPath 'video_stream.mp4' -Type Video -Index 0`
    * Extracts the first video stream from 'video.mp4' and saves it as 'video_stream.mp4'.

1. `Export-MediaStream -InputPath 'video.mp4' -OutputPath 'subtitle.sup' -Type Subtitle -Index 0`
   * Extracts the first subtitle stream from 'video.mp4' and saves it as 'subtitle.sup'.

1. `Export-MediaStream -InputPath 'video.mp4' -OutputPath 'stream_2.data' -Type Data -Index 2 -Force`
    * Extracts the third data stream from 'video.mp4' and saves it as 'stream_2.data', overwriting if it exists.

1. `"video.mp4" | Export-MediaStream -OutputPath "audio.ac3" -Type Audio -Index 0`
    * Extracts the first audio stream 'video.mp4' and saves it as "audio.ac3".

1. `Export-MediaStream -InputPath 'video.mp4' -OutputPath 'stream_3.raw' -Type None -Index 3`
    * Extracts the fourth stream (absolute index 3) from 'video.mp4' regardless of its type and saves it as 'stream_3.raw'.
