### PR TITLE
Rewrite Get-MediaStreams

### DIFF
--- a/PowerShell/VideoUtility/Install.ps1
+++ b/PowerShell/VideoUtility/Install.ps1
@@ -61,13 +61,6 @@ try {
     Import-Module VideoUtility -Force -ErrorAction Stop
     Write-Host 'VideoUtility module installed successfully!' -ForegroundColor Green
     Write-Host "Module location: $moduleRoot" -ForegroundColor Cyan
-    
-    # Show available functions
-    $functions = Get-Command -Module VideoUtility
-    if ($functions) {
-        Write-Host 'Available functions:' -ForegroundColor Yellow
-        $functions | ForEach-Object { Write-Host "  - $($_.Name)" -ForegroundColor White }
-    }
 }
 catch {
     Write-Error "Failed to install VideoUtility module: $($_.Exception.Message)"

--- a/PowerShell/VideoUtility/Public/Get-MediaStreams.ps1
+++ b/PowerShell/VideoUtility/Public/Get-MediaStreams.ps1
@@ -11,8 +11,8 @@ function Get-MediaStreams {
         Retrieves an array of streams from a media file.
 
     .DESCRIPTION
-        Scans a media file and returns all streams (audio, video, subtitle, etc).
-        Optionally filters by stream type and/or language code.
+        Scans a media file using ffprobe and returns filtered streams.
+        Each stream object contains Index, CodecType, CodecName, Language, Disposition, and Tags properties.
 
     .PARAMETER Path
         Path to the media file.
@@ -21,28 +21,24 @@ function Get-MediaStreams {
         Type of stream to retrieve ('Audio', 'Video', 'Subtitle', or 'All').
         Default is 'All'.
 
-    .PARAMETER Language
-        Language code to filter streams (e.g., 'eng' for English).
-
     .EXAMPLE
-        Get-MediaStreams 'example.mp4' -Type Audio -Language 'eng'
-        # Retrieves all English audio streams from 'example.mp4'.
+        Get-MediaStreams 'example.mp4' -Type Audio
+        # Retrieves all audio streams from 'example.mp4'.
 
     .EXAMPLE
         Get-MediaStreams 'example.mp4' -Type Video
         # Retrieves all video streams from 'example.mp4'.
 
     .EXAMPLE
-        Get-MediaStreams 'example.mp4' -Type Subtitle -Language 'eng'
-        # Retrieves all English subtitle streams from 'example.mp4'.
+        Get-MediaStreams 'example.mp4' -Type Subtitle
+        # Retrieves all subtitle streams from 'example.mp4'.
 
     .EXAMPLE
         Get-MediaStreams 'example.mp4'
-        # Retrieves all streams from 'example.mp4' with no filtering.
+        # Retrieves all streams from 'example.mp4'.
 
     .OUTPUTS
-        [object[]] Array of stream objects, each with stream index,
-        type, and language info.
+        [object[]] Array of stream objects with Index, CodecType, CodecName, Language, Disposition, and Tags properties.
 
     .NOTES
         Requires ffmpeg/ffprobe to be installed and available in the system PATH.
@@ -53,66 +49,76 @@ function Get-MediaStreams {
         [Parameter(Mandatory = $true, Position = 0)]
         [string]$Path,
         [Parameter(Position = 1)]
-        [StreamType]$Type = [StreamType]::All,
-        [Parameter()]
-        [string]$Language
+        [StreamType]$Type = [StreamType]::All
     )
 
-    # Validate the file path before proceeding
-    if (-not (Test-Path -Path $Path -PathType Leaf)) {
-        Write-Error "The file path '$Path' does not exist or is not a valid file." -ErrorAction Stop
-    }
-
-    # Resolve path relative to current working directory
+    # Resolve path to absolute path
     if ([System.IO.Path]::IsPathRooted($Path)) {
-        # Absolute path - use as is
-        $Path = [System.IO.Path]::GetFullPath($Path)
+        $resolvedPath = $Path
     }
     else {
-        # Relative path - resolve relative to current working directory
-        $Path = Join-Path (Get-Location) $Path
-        $Path = [System.IO.Path]::GetFullPath($Path)
-    }
-    Write-Verbose "Output path resolved: $Path"
-
-    # Get all streams from the file using ffprobe
-    $ffprobeResult = Invoke-FFProbe '-show_streams', $Path
-    $streams = $ffprobeResult.streams
-
-    # Return an empty array if no streams are found
-    if (-not $streams) {
-        Write-Verbose "No streams found in file '$Path'."
-        return @()
+        $resolvedPath = Join-Path (Get-Location) $Path
     }
 
-    # Prepare to collect filtered streams
-    $filteredStreams = [System.Collections.ArrayList]::new()
-    $streamTypeString = $Type.ToString().ToLowerInvariant()
+    # Validate the file path before proceeding
+    if (-not (Test-Path -Path $resolvedPath -PathType Leaf)) {
+        Write-Error "The file path '$resolvedPath' does not exist or is not a valid file." -ErrorAction Stop
+    }
 
-    for ($i = 0; $i -lt $streams.Count; $i++) {
-        $stream = $streams[$i]
+    Write-Verbose "Processing file: $resolvedPath"
 
-        # Check if the stream matches the requested type and language
-        $matchesType = ($Type -eq [StreamType]::All) -or ($stream.codec_type -eq $streamTypeString)
-        $matchesLanguage = (-not $Language) -or ($stream.tags.language -eq $Language)
+    try {
+        # Get all streams from the file using ffprobe
+        Write-Verbose "Running ffprobe to get stream information"
+        $ffprobeResult = Invoke-FFProbe '-show_streams', $resolvedPath
+        
+        # Get streams from the result object
+        $allStreams = $ffprobeResult.streams
 
-        if ($matchesType -and $matchesLanguage) {
-            # Build a custom object for each matching stream
-            $streamObj = [PSCustomObject]@{
-                Index       = $stream.index
-                CodecType   = $stream.codec_type
-                TypeIndex   = if ($Type -ne [StreamType]::All) { $filteredStreams.Count } else { $null }
-                CodecName   = $stream.codec_name
-                Language    = $stream.tags.language
-                Disposition = $stream.disposition
-                Tags        = $stream.tags
-                # Convert the stream to a JSON object and back to a PSObject to deep copy the object
-                Stream      = $stream | ConvertTo-Json | ConvertFrom-Json
-            }
-            $filteredStreams.Add($streamObj) | Out-Null
+        # Return empty array if no streams found
+        if (-not $allStreams) {
+            Write-Verbose "No streams found in file '$resolvedPath'"
+            return @()
         }
-    }
 
-    # Return the array of filtered stream objects
-    return , $filteredStreams.ToArray()
+        Write-Verbose "Found $($allStreams.Count) total streams"
+
+        # Filter streams based on type
+        $filteredStreams = @()
+        $streamTypeString = $Type.ToString().ToLowerInvariant()
+
+        foreach ($stream in $allStreams) {
+            # Check if stream matches the requested type
+            $matchesType = ($Type -eq [StreamType]::All) -or ($stream.codec_type -eq $streamTypeString)
+            
+            if ($matchesType) {
+                Write-Verbose "Processing stream $($stream.index) of type $($stream.codec_type)"
+                
+                # Extract language from tags, default to empty string if not present
+                $language = if ($stream.tags -and $stream.tags.language) { 
+                    $stream.tags.language 
+                } else { 
+                    "" 
+                }
+
+                # Create stream object with required properties
+                $streamObj = [PSCustomObject]@{
+                    Index       = [int]$stream.index - 1
+                    CodecType   = [string]$stream.codec_type
+                    CodecName   = [string]$stream.codec_name
+                    Language    = [string]$language
+                    Disposition = $stream.disposition
+                    Tags        = $stream.tags
+                }
+
+                $filteredStreams += $streamObj
+            }
+        }
+
+        Write-Verbose "Returning $($filteredStreams.Count) filtered streams of type '$Type'"
+        return $filteredStreams
+    }
+    catch {
+        Write-Error "Failed to get media streams from '$resolvedPath': $($_.Exception.Message)" -ErrorAction Stop
+    }
 }


### PR DESCRIPTION
`Get-MediaStream` is broken. This change rewrites it from scratch. Note that the `Language` filter has been removed. Caller can filter the streams manually.