### PR TITLE
Use ProcessStartInfo.Arguments instead of ProcessStartInfo.ArgumentList

### DIFF
--- a/PowerShell/VideoUtility/Public/Invoke-Process.ps1
+++ b/PowerShell/VideoUtility/Public/Invoke-Process.ps1
@@ -54,9 +54,7 @@ function Invoke-Process {
         WorkingDirectory       = (Get-Location).Path
     }
 
-    foreach ($arg in $Arguments) {
-        [void]$psi.ArgumentList.Add($arg)
-    }
+    $psi.Arguments = $Arguments -join ' '
 
     Write-Verbose "Invoke-Process: Process Info: FileName: $($psi.FileName) Arguments: $($psi.ArgumentList)"
 


### PR DESCRIPTION
## Summary
This PR includes the following changes:

## Commits
• 9519262 Use ProcessStartInfo.Arguments instead of ProcessStartInfo.ArgumentList

## Files Changed
• PowerShell/VideoUtility/Public/Invoke-Process.ps1
