### PR TITLE
Fix Get-MediaStreams and Get-MediaStream to properly quote filenames

### DIFF
--- a/PowerShell/VideoUtility/Public/Get-MediaStream.ps1
+++ b/PowerShell/VideoUtility/Public/Get-MediaStream.ps1
@@ -69,7 +69,8 @@ function Get-MediaStream {
         $codecFilter = "$t`:"
     }
 
-    $processResult = Invoke-FFProbe '-select_streams', "$codecFilter$Index", '-show_streams', $Name
+    $quotedName = '"' + $Name + '"'
+    $processResult = Invoke-FFProbe '-select_streams', "$codecFilter$Index", '-show_streams', $quotedName
     if ($processResult.ExitCode) {
         Write-Error "Get-MediaStream: Failed to get media stream. Exit code: $($processResult.ExitCode)"
         return $null

--- a/PowerShell/VideoUtility/Public/Get-MediaStreams.ps1
+++ b/PowerShell/VideoUtility/Public/Get-MediaStreams.ps1
@@ -75,7 +75,8 @@ function Get-MediaStreams {
         try {
             # Get all streams from the file using ffprobe
             Write-Verbose 'Running ffprobe to get stream information'
-            $processResult = Invoke-FFProbe '-show_streams', "`"$resolvedPath`""
+            $quotedPath = '"' + $resolvedPath + '"'
+            $processResult = Invoke-FFProbe '-show_streams', $quotedPath
             if ($processResult.ExitCode) {
                 Write-Error "Get-MediaStreams: Failed to get media streams. Exit code: $($processResult.ExitCode)"
                 return @()


### PR DESCRIPTION
## Summary
This PR includes the following changes:

## Commits
• 34e5426 Fix Get-MediaStreams and Get-MediaStream to properly quote filenames

## Files Changed
• PowerShell/VideoUtility/Public/Get-MediaStream.ps1
• PowerShell/VideoUtility/Public/Get-MediaStreams.ps1
