### PR TITLE
Fix usage of wrong variable name in MediaStreamInfoCollection.ExportFile

### DIFF
--- a/PowerShell/VideoUtility/Public/MediaStreamInfoCollection.ps1
+++ b/PowerShell/VideoUtility/Public/MediaStreamInfoCollection.ps1
@@ -204,12 +204,12 @@ class MediaStreamInfoCollection {
             $fileFFMpegArgs += $stream.GetFFMpegOutputArgs($outputFile)
         }
 
-        $quotedInputPath = '"' + $filePath + '"'
+        $quotedInputPath = '"' + $File + '"'
         $fileFFMpegArgs += @('-i', $quotedInputPath, '-y')
         $result = Invoke-FFMpeg -Arguments $fileFFMpegArgs
 
         if ($result.ExitCode -ne 0) {
-            Write-Error "Failed to export streams for file '$filePath'"
+            Write-Error "Failed to export streams for file '$File'"
         }
     }
 


### PR DESCRIPTION
## Summary
This PR includes the following changes:

## Commits
• 1f523c9 Fix usage of wrong variable name in MediaStreamInfoCollection.ExportFile

## Files Changed
• PowerShell/VideoUtility/Public/MediaStreamInfoCollection.ps1
